### PR TITLE
sqlite library fix.

### DIFF
--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -92,7 +92,7 @@ macro(add_plugin_libraries)
   add_subdirectory("${CMAKE_SOURCE_DIR}/opencpn-libs/plugingl")
   target_link_libraries(${PACKAGE_NAME} ocpn::plugingl)
   
-  add_subdirectory("${CMAKE_SOURCE_DIR}/libs/sqlite")
+  add_subdirectory("${CMAKE_SOURCE_DIR}/opencpn-libs/sqlite")
   target_link_libraries(${PACKAGE_NAME} sqlite::sqlite)  
 
   # The wxsvg library enables SVG overall in the plugin

--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -93,7 +93,7 @@ macro(add_plugin_libraries)
   target_link_libraries(${PACKAGE_NAME} ocpn::plugingl)
   
   add_subdirectory("${CMAKE_SOURCE_DIR}/opencpn-libs/sqlite")
-  target_link_libraries(${PACKAGE_NAME} sqlite::sqlite)  
+  target_link_libraries(${PACKAGE_NAME} ocpn::sqlite)  
 
   # The wxsvg library enables SVG overall in the plugin
   add_subdirectory("${CMAKE_SOURCE_DIR}/opencpn-libs/wxsvg")


### PR DESCRIPTION
I have updated opencpn-libs with a somewhat simple-minded patch. It bundles FindSqlite for cmake versions < 3.14.0, and uses FindSqlite3 which part of cmake for newer versions.

Some small fixes to Plugin.cmake to accomodate these changes.

Enjoy